### PR TITLE
Upgrade to ruby 2.6.3 (alpine 3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## v1.1.1-alpine3.10 (14/07/2019)
+
+- Using docker image FROM ruby:2.6.3-alpine3.10
+  - upgradde to alpine 3.10
+  - upgrade to ruby 2.6.3
+
 ## v1.1.0-alpine3.8 (27/10/2018)
 
 - Using docker image FROM ruby:2.5.3-alpine3.8
-  * upgrade to alpine 3.8
-  * upgrade to ruby 2.5.3
+  - upgrade to alpine 3.8
+  - upgrade to ruby 2.5.3
 
 ## v1.0.1-alpine3.7 (03/02/2018)
 
@@ -16,4 +22,3 @@
 ## Used to be able to have historical releases in docker hub (03/10/2017)
 
 - alpine 3.6 at this time
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3-alpine3.8
+FROM ruby:2.6.3-alpine3.10
 
 LABEL maintainer "Ramón G. Camus <rgcamus@gmail.com>"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Smashing Alpine Container:  Smashing is the new http://dashing.io fork name. 
+# Smashing Alpine Container:  The new <http://dashing.io> fork name
 
 Run [Smashing](https://github.com/Smashing/smashing) in a minimal [Alpine](https://alpinelinux.org/about/) [Docker](http://docker.io/) container.
 
@@ -17,22 +17,25 @@ Link: [rgcamus/alpine_smashing](https://registry.hub.docker.com/u/rgcamus/alpine
 
 ```cd dockerfile-alpine_smashing```
 
-```docker build -t alpine_smashing . ```
+```docker build -t alpine_smashing .```
 
 ## Run
+
 ```docker run -d -p 8080:3030 rgcamus/alpine_smashing```
 
 And point your browser to [http://localhost:8080/](http://localhost:8080/),
 or to [http://localhost:8080/sampletv](http://localhost:8080/sampletv) for a 1080p TV layout.
 
-
 ## Configuration
+
 ### Custom smashing port
+
 If you want smashing to use a custom port inside the container, e g 8080, use the environment variable `$PORT`:
 
 ```docker run -d -e PORT=8080 -p 80:8080 rgcamus/alpine_smashing```
 
 ### Dashboards
+
 To provide a custom dashboard, use container volume **/dashboards**:
 
 ```docker run -v=/my/custom/dashboards:/dashboards -d -p 8080:3030 rgcamus/alpine_smashing```
@@ -40,11 +43,13 @@ To provide a custom dashboard, use container volume **/dashboards**:
 (*Don't forget to also provide the layout.erb*)
 
 ### Jobs
+
 To provide custom jobs, use container volume **/jobs**:
 
 ```docker run -v=/my/cool/job:/jobs -d -p 8080:3030 rgcamus/alpine_smashing```
 
 ### Widgets
+
 To install custom widgets supply the gist IDs of the widgets as an environment variable:
 
 ```docker run -d -e WIDGETS=5641535 -p 8080:3030 rgcamus/alpine_smashing```
@@ -56,8 +61,8 @@ Also you can use local custom widgets
 
 ```docker run -v=/my/cool/widgets:/widgets -d -p 8080:3030 rgcamus/alpine_smashing```
 
-
 ### Gems
+
 To install gems, supply the gem name(s) as an environment variable:
 
 ```docker run -d -e GEMS=instagram -e WIDGETS=5278790 -p 8080:3030 rgcamus/alpine_smashing```
@@ -68,18 +73,23 @@ which depends on the instagram gem. Multiple gems and widgets can be supplied li
 ```docker run -d -e GEMS="mysql instagram" -e WIDGETS=5278790 -p 8080:3030 rgcamus/alpine_smashing```
 
 ### Public (favicon, 404)
+
 To provide custom 404 and favicon, use container volume **/public**.
 
 ### Configuration File
+
 The configuration file ```config.ru``` is available on volume */config*.
 
 Edit this file to change your API key, to add authentication and more.
+
 ### lib volume
+
 The smashing lib dir is available on volume */lib-smashing*.
 
 Note: This is a fork of the dockerfile-dashing. Read about that [here](http://github.com/frvi/dockerfile-dashing)
 
 ## Thanks
+
 - [@frvi](https://github.com/frvi), original author of run.sh)
 - [@mattgruter](https://github.com/mattgruter), awesome contributions!
 - [@rowanu](https://github.com/rowanu), [Hotness Widget](https://gist.github.com/rowanu/6246149).
@@ -87,4 +97,5 @@ Note: This is a fork of the dockerfile-dashing. Read about that [here](http://gi
 - [@chelsea](https://github.com/chelsea), [Random Aww](https://gist.github.com/chelsea/5641535).
 
 ## License
+
 Distributed under the MIT license


### PR DESCRIPTION
- Using Docker image FROM ruby:2.6.3-alpine3.10
  - upgrade to alpine 3.10
  - upgrade to ruby 2.6.3